### PR TITLE
removing default features from tide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/jbr/driftwood"
 
 
 [dependencies]
-tide = "0.16.0"
+tide = { version = "0.16.0", default-features = false }
 chrono = "0.4.19"
 colored = "2.0.0"
 size = "0.4.0"


### PR DESCRIPTION
This disables the defaults in tide, specifically targeting the "logger" feature, which removes duplicate logging - similar to your mention of `tide-rustls` invoking extra features in https://github.com/http-rs/tide/issues/548

It doesn't seem to break anything in my tests?